### PR TITLE
hotfix/TOPS-800: Renaming gsoft-inc organization to workleap in github.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 ### Adding a new icon
 
 1. First, follow this procedure to release the new icons in the `@hopper-ui/icons` and `@hopper-ui/svg-icons` package:
-https://github.com/gsoft-inc/wl-hopper/blob/main/CONTRIBUTING.md#adding-a-new-icon
+https://github.com/workleap/wl-hopper/blob/main/CONTRIBUTING.md#adding-a-new-icon
 
 2. Update the @hopper-ui/svg-icons dev dependency in packages\icons-react16\package.json and run `pnpm install` in the root directory.
 
@@ -29,6 +29,6 @@ pnpm changeset
 ### Updating or removing an icon
 
 - First, follow this procedure to remove or icons in the `@hopper-ui/icons` and `@hopper-ui/svg-icons` package:
-https://github.com/gsoft-inc/wl-hopper/blob/main/CONTRIBUTING.md#updating-or-removing-an-icon
+https://github.com/workleap/wl-hopper/blob/main/CONTRIBUTING.md#updating-or-removing-an-icon
 
 - Steps 2-4 are the same as adding a new icon.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Before starting make sure [node](https://nodejs.org/en/) and [pnpm](https://pnpm
 After cloning the source code, run `pnpm` to install dependencies.
 
 ```bash
-git clone https://github.com/gsoft-inc/wl-hopper-react16.git
+git clone https://github.com/workleap/wl-hopper-react16.git
 cd wl-hopper-react16
 pnpm i
 ```
@@ -25,8 +25,8 @@ pnpm i
 
 ## 🤝 Contributing
 
-Pull requests are welcome. For major changes, please open a [discussions](https://github.com/gsoft-inc/wl-hopper/discussions/new/choose) first to discuss what you would like to change. If you're interested, definitely check out our Contributing Guide!
+Pull requests are welcome. For major changes, please open a [discussions](https://github.com/workleap/wl-hopper/discussions/new/choose) first to discuss what you would like to change. If you're interested, definitely check out our Contributing Guide!
 
 ## License
 
-Copyright © 2023, GSoft inc. This code is licensed under the Apache License, Version 2.0. You may obtain a copy of this license at https://github.com/gsoft-inc/gsoft-license/blob/master/LICENSE.
+Copyright © 2023, GSoft inc. This code is licensed under the Apache License, Version 2.0. You may obtain a copy of this license at https://github.com/workleap/gsoft-license/blob/master/LICENSE.

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "type": "module",
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/gsoft-inc/wl-hopper-react16.git"
+        "url": "git+https://github.com/workleap/wl-hopper-react16.git"
     },
     "scripts": {
         "build": "pnpm -r build ",
@@ -41,8 +41,8 @@
         "ts-node": "10.9.1"
     },
     "bugs": {
-        "url": "https://github.com/gsoft-inc/wl-hopper/issues"
+        "url": "https://github.com/workleap/wl-hopper/issues"
     },
-    "readme": "https://github.com/gsoft-inc/wl-hopper#readme",
-    "homepage": "https://github.com/gsoft-inc/wl-hopper#readme"
+    "readme": "https://github.com/workleap/wl-hopper#readme",
+    "homepage": "https://github.com/workleap/wl-hopper#readme"
 }

--- a/packages/icons-react16/README.md
+++ b/packages/icons-react16/README.md
@@ -57,8 +57,8 @@ View the [library](https://wl-hopper.netlify.app/icons/react-icons/library).
 
 ## 🤝 Contributing
 
-View the [contributor's documentation](https://github.com/gsoft-inc/wl-hopper/blob/main/CONTRIBUTING.md).
+View the [contributor's documentation](https://github.com/workleap/wl-hopper/blob/main/CONTRIBUTING.md).
 
 ## License
 
-Copyright © 2023, Workleap. This code is licensed under the Apache License, Version 2.0. You may obtain a copy of this license at https://github.com/gsoft-inc/workleap-license/blob/master/LICENSE.
+Copyright © 2023, Workleap. This code is licensed under the Apache License, Version 2.0. You may obtain a copy of this license at https://github.com/workleap/workleap-license/blob/master/LICENSE.

--- a/packages/icons-react16/package.json
+++ b/packages/icons-react16/package.json
@@ -6,7 +6,7 @@
     "license": "Apache-2.0",
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/gsoft-inc/wl-hopper-react16.git",
+        "url": "git+https://github.com/workleap/wl-hopper-react16.git",
         "directory": "packages/icons-react16"
     },
     "publishConfig": {


### PR DESCRIPTION
TOPS-800: Replacing gsoft-inc/wl-reusable-workflows by workleap/wl-reusable-workflows

--
Not sure why this PR has been created? Reach TechOps in our public slack channel: #techops-and-friends
Some context on the why of this PR can be found here: https://workleap.slack.com/archives/C02E9KPRQ7P/p1737385211295479 